### PR TITLE
도메인 클래스 추가 및 place api 컨트롤러 및 컨트롤러 테스트 추가

### DIFF
--- a/src/main/java/com/example/realtimeusage/constant/EventStatus.java
+++ b/src/main/java/com/example/realtimeusage/constant/EventStatus.java
@@ -1,0 +1,5 @@
+package com.example.realtimeusage.constant;
+
+public enum EventStatus {
+    PENDING, OPENED, CLOSEDD, CANCELED, ABORTED;
+}

--- a/src/main/java/com/example/realtimeusage/constant/PlaceType.java
+++ b/src/main/java/com/example/realtimeusage/constant/PlaceType.java
@@ -1,0 +1,5 @@
+package com.example.realtimeusage.constant;
+
+public enum PlaceType {
+    COMMON, SPORTS, RESTAURANT, PARTY;
+}

--- a/src/main/java/com/example/realtimeusage/controller/api/APIPlaceController.java
+++ b/src/main/java/com/example/realtimeusage/controller/api/APIPlaceController.java
@@ -1,0 +1,66 @@
+package com.example.realtimeusage.controller.api;
+
+import com.example.realtimeusage.constant.PlaceType;
+import com.example.realtimeusage.dto.APIDataResponse;
+import com.example.realtimeusage.dto.PlaceDto;
+import com.example.realtimeusage.dto.PlaceResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/places")
+@RequiredArgsConstructor
+public class APIPlaceController {
+    @GetMapping
+    public APIDataResponse<List<PlaceResponse>> getPlaces() {
+        return APIDataResponse.of(List.of(
+                PlaceResponse.of(
+                        "배드민턴장",
+                        PlaceType.COMMON,
+                        "서울시 강남구",
+                        "010-1234-5678",
+                        30,
+                        "신장개업")
+        ));
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public Boolean createPlace() {
+        return true;
+    }
+
+    @GetMapping("/{placeId}")
+    public APIDataResponse<PlaceDto> getPlace(@PathVariable Long placeId) {
+        if (placeId != 1) {
+            return APIDataResponse.empty();
+        }
+        return APIDataResponse.of(PlaceDto.of(
+                PlaceType.COMMON,
+                "배드민턴장",
+                "서울시 강남구",
+                "010-1234-5678",
+                30,
+                "신장개업")
+        );
+    }
+
+    @PutMapping("/{placeId}")
+    public Boolean modifyPlace(@PathVariable Long placeId) {
+        return true;
+    }
+
+    @DeleteMapping("/{placeId}")
+    public Boolean deletePlace(@PathVariable Long placeId) {
+        return true;
+    }
+}

--- a/src/main/java/com/example/realtimeusage/controller/error/APIExceptionHandler.java
+++ b/src/main/java/com/example/realtimeusage/controller/error/APIExceptionHandler.java
@@ -3,32 +3,54 @@ package com.example.realtimeusage.controller.error;
 import com.example.realtimeusage.constant.ErrorCode;
 import com.example.realtimeusage.dto.APIErrorResponse;
 import com.example.realtimeusage.exception.GeneralException;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-//@RestControllerAdvice(annotations = RestController.class)
-public class APIExceptionHandler {
+@RestControllerAdvice(annotations = RestController.class)
+public class APIExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<APIErrorResponse> error(GeneralException e) {
+    public ResponseEntity<Object> error(GeneralException e, HttpServletResponse response, WebRequest request) {
         ErrorCode errorCode = e.getErrorCode();
         HttpStatus status = errorCode.isClientSideError() ? HttpStatus.BAD_REQUEST : HttpStatus.INTERNAL_SERVER_ERROR;
 
-        return ResponseEntity
-                .status(status)
-                .body(APIErrorResponse.of(errorCode, errorCode.getMessage(status.getReasonPhrase())));
+        return super.handleExceptionInternal(e,
+                APIErrorResponse.of(errorCode.getCode(),
+                        errorCode.getMessage(e.getMessage())),
+                HttpHeaders.EMPTY,
+                status,
+                request);
     }
 
     @ExceptionHandler
-    public ResponseEntity<APIErrorResponse> error(Exception e) {
+    public ResponseEntity<Object> error(Exception e, WebRequest request) {
         ErrorCode errorCode = ErrorCode.INTERNAL_ERROR;
         HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
 
-        return ResponseEntity
-                .status(status)
-                .body(APIErrorResponse.of(errorCode, errorCode.getMessage(status.getReasonPhrase())));
+        return super.handleExceptionInternal(e,
+                APIErrorResponse.of(errorCode.getCode(),
+                        errorCode.getMessage(e.getMessage())),
+                HttpHeaders.EMPTY,
+                status,
+                request);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers,
+                                                             HttpStatus status, WebRequest request) {
+        ErrorCode errorCode =
+                status.is4xxClientError() ?
+                        ErrorCode.SPRING_BAD_REQUEST :
+                        ErrorCode.SPRING_INTERNAL_ERROR;
+        return super.handleExceptionInternal(ex,
+                APIErrorResponse.of(errorCode.getCode(), errorCode.getMessage(ex.getMessage())), headers, status,
+                request);
     }
 }

--- a/src/main/java/com/example/realtimeusage/controller/error/BaseErrorController.java
+++ b/src/main/java/com/example/realtimeusage/controller/error/BaseErrorController.java
@@ -2,26 +2,31 @@ package com.example.realtimeusage.controller.error;
 
 import com.example.realtimeusage.constant.ErrorCode;
 import com.example.realtimeusage.dto.APIErrorResponse;
+import java.util.Map;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 public class BaseErrorController implements ErrorController {
     @GetMapping(value = "/error", produces = MediaType.TEXT_HTML_VALUE)
-    public String error(Model model, HttpServletResponse response) {
+    public ModelAndView errorHtml(HttpServletResponse response) {
         HttpStatus status = HttpStatus.valueOf(response.getStatus());
         ErrorCode errorCode = status.is4xxClientError() ? ErrorCode.BAD_REQUEST : ErrorCode.INTERNAL_ERROR;
 
-        model.addAttribute("statusCode", status.value());
-        model.addAttribute("errorCode", errorCode);
-        model.addAttribute("message", errorCode.getMessage(status.getReasonPhrase()));
-        return "error";
+        return new ModelAndView(
+                "error",
+                Map.of(
+                        "statusCode", status.value(),
+                        "errorCode", errorCode,
+                        "message", errorCode.getMessage(status.getReasonPhrase())
+                ),
+                status);
     }
 
     @GetMapping("/error")

--- a/src/main/java/com/example/realtimeusage/domain/Admin.java
+++ b/src/main/java/com/example/realtimeusage/domain/Admin.java
@@ -1,0 +1,17 @@
+package com.example.realtimeusage.domain;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class Admin {
+    private Long id;
+    private String email;
+    private String password;
+    private String nickName;
+    private String phoneNumber;
+    private String memo;
+    private LocalDateTime creatdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/realtimeusage/domain/Event.java
+++ b/src/main/java/com/example/realtimeusage/domain/Event.java
@@ -1,0 +1,21 @@
+package com.example.realtimeusage.domain;
+
+import com.example.realtimeusage.constant.EventStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class Event {
+    private Long id;
+    private Long placeId;
+    private String name;
+    private LocalDateTime startDateTime;
+    private LocalDateTime endDateTime;
+    private int capacity;
+    private int currentNumberOfPeople;
+    private EventStatus status;
+    private String memo;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/realtimeusage/domain/Place.java
+++ b/src/main/java/com/example/realtimeusage/domain/Place.java
@@ -1,0 +1,18 @@
+package com.example.realtimeusage.domain;
+
+import com.example.realtimeusage.constant.PlaceType;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class Place {
+    private Long id;
+    private String name;
+    private PlaceType type;
+    private String address;
+    private String phoneNumber;
+    private int capacity;
+    private String memo;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/realtimeusage/dto/PlaceDto.java
+++ b/src/main/java/com/example/realtimeusage/dto/PlaceDto.java
@@ -1,0 +1,23 @@
+package com.example.realtimeusage.dto;
+
+import com.example.realtimeusage.constant.PlaceType;
+
+public record PlaceDto(
+        PlaceType type,
+        String name,
+        String address,
+        String phoneNumber,
+        Integer capacity,
+        String memo
+) {
+    public static PlaceDto of(
+            PlaceType type,
+            String name,
+            String address,
+            String phoneNumber,
+            Integer capacity,
+            String memo) {
+        return new PlaceDto(type, name, address, phoneNumber, capacity, memo);
+    }
+
+}

--- a/src/main/java/com/example/realtimeusage/dto/PlaceResponse.java
+++ b/src/main/java/com/example/realtimeusage/dto/PlaceResponse.java
@@ -1,0 +1,22 @@
+package com.example.realtimeusage.dto;
+
+import com.example.realtimeusage.constant.PlaceType;
+
+public record PlaceResponse(
+        String name,
+        PlaceType type,
+        String address,
+        String phoneNumber,
+        int capacity,
+        String memo
+) {
+    public static PlaceResponse of(
+            String name,
+            PlaceType type,
+            String address,
+            String phoneNumber,
+            int capacity,
+            String memo) {
+        return new PlaceResponse(name, type, address, phoneNumber, capacity, memo);
+    }
+}

--- a/src/test/java/com/example/realtimeusage/controller/BaseControllerTest.java
+++ b/src/test/java/com/example/realtimeusage/controller/BaseControllerTest.java
@@ -1,0 +1,33 @@
+package com.example.realtimeusage.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BaseController.class)
+class BaseControllerTest {
+    private final MockMvc mockMvc;
+
+    public BaseControllerTest(@Autowired MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @DisplayName("[view] [GET] 기본 페이지 요청")
+    @Test
+    void basePageShouldShowIndexPage() throws Exception {
+        //when & then
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(content().string(containsString("This is default page")));
+    }
+
+}

--- a/src/test/java/com/example/realtimeusage/controller/api/APIPlaceControllerTest.java
+++ b/src/test/java/com/example/realtimeusage/controller/api/APIPlaceControllerTest.java
@@ -1,0 +1,81 @@
+package com.example.realtimeusage.controller.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.realtimeusage.constant.ErrorCode;
+import com.example.realtimeusage.constant.PlaceType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(APIPlaceController.class)
+class APIPlaceControllerTest {
+    private final MockMvc mockMvc;
+
+    public APIPlaceControllerTest(@Autowired MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @DisplayName("[API] [GET] 장소 리스트 조회")
+    @Test
+    void requestPlaceListShouldReturnStandardResponseOfPlaceList() throws Exception {
+        //when & then
+        mockMvc.perform(get("/api/places"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].type").value(PlaceType.COMMON.name()))
+                .andExpect(jsonPath("$.data[0].name").value("배드민턴장"))
+                .andExpect(jsonPath("$.data[0].address").value("서울시 강남구"))
+                .andExpect(jsonPath("$.data[0].phoneNumber").value("010-1234-5678"))
+                .andExpect(jsonPath("$.data[0].capacity").value(30))
+                .andExpect(jsonPath("$.data[0].memo").value("신장개업"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.OK.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.OK.getMessage()));
+    }
+
+    @DisplayName("[API] [GET] 장소 조회")
+    @Test
+    void requestPlaceShouldReturnPlaceDetail() throws Exception {
+        //given
+        int placeId = 1;
+
+        //when & then
+        mockMvc.perform(get("/api/places/{placeId}", placeId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.type").value(PlaceType.COMMON.name()))
+                .andExpect(jsonPath("$.data.name").value("배드민턴장"))
+                .andExpect(jsonPath("$.data.address").value("서울시 강남구"))
+                .andExpect(jsonPath("$.data.phoneNumber").value("010-1234-5678"))
+                .andExpect(jsonPath("$.data.capacity").value(30))
+                .andExpect(jsonPath("$.data.memo").value("신장개업"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.OK.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.OK.getMessage()));
+    }
+
+    @DisplayName("[API] [GET] 장소 조회 - 장소 없는 경우")
+    @Test
+    void requestNotExistPlaceShouldReturnError() throws Exception {
+        //given
+        int placeId = 2;
+
+        //when & then
+        mockMvc.perform(get("/api/places/{placeId}", placeId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.OK.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.OK.getMessage()));
+    }
+}

--- a/src/test/java/com/example/realtimeusage/controller/error/BaseErrorControllerTest.java
+++ b/src/test/java/com/example/realtimeusage/controller/error/BaseErrorControllerTest.java
@@ -1,0 +1,36 @@
+package com.example.realtimeusage.controller.error;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BaseErrorController.class)
+class BaseErrorControllerTest {
+    private final MockMvc mockMvc;
+
+    public BaseErrorControllerTest(@Autowired MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @DisplayName("[view] [GET] 없는 페이지 요청")
+    @Test
+    void wrongURIRequestShouldReturnErrorPage() throws Exception {
+        //when & then
+        mockMvc.perform(get("/wrong-uri"))
+                .andExpect(status().isNotFound())
+                .andDo(print());
+    }
+
+}

--- a/src/test/java/com/example/realtimeusage/dto/APIDataResponseTest.java
+++ b/src/test/java/com/example/realtimeusage/dto/APIDataResponseTest.java
@@ -1,0 +1,50 @@
+package com.example.realtimeusage.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.realtimeusage.constant.ErrorCode;
+import com.example.realtimeusage.constant.PlaceType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class APIDataResponseTest {
+    @DisplayName("데이터가 주어지면 표준 성공 응답을 생성한다.")
+    @Test
+    void creatingResponseShouldReturnSuccessfulResponse() {
+        //given
+        PlaceDto data = PlaceDto.of(PlaceType.PARTY,
+                "place",
+                "place address",
+                "0101111111",
+                10,
+                "");
+        //when
+        APIDataResponse<String> response = APIDataResponse.of(data);
+
+        //then
+        assertThat(response)
+                .hasFieldOrPropertyWithValue("success", true)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OK.getCode())
+                .hasFieldOrPropertyWithValue("message", ErrorCode.OK.getMessage())
+                .hasFieldOrPropertyWithValue("data", data);
+
+        assertThat(response.getData())
+                .isInstanceOf(PlaceDto.class);
+    }
+
+    @DisplayName("데이터가 없으면 비어있는 표준 성공 응답을 생성한다.")
+    @Test
+    void creatingResponseWithoutDataShouldReturnEmptySuccessfulResponse() {
+        //when
+        APIDataResponse<String> response = APIDataResponse.empty();
+
+        //then
+        assertThat(response)
+                .hasFieldOrPropertyWithValue("success", true)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OK.getCode())
+                .hasFieldOrPropertyWithValue("message", ErrorCode.OK.getMessage())
+                .hasFieldOrPropertyWithValue("data", null);
+        assertThat(response.getData())
+                .isNull();
+    }
+}


### PR DESCRIPTION
1. 도메인 클래스 추가
- 컨트롤러 개발 용이하도록 기본 형태의 도메인 추가
- 이후 jpa entity로 교체 예정

2. APIPlaceController 추가
- crud 엔드포인트 생성 및 응답 dto 생성
- 기본 응답 테스트 위해 임시 데이터 반환. 이후 서비스 레이어 추가 예정

4. 컨트롤러 테스트 추가
- 표준 성공 응답 테스트
- 공통 Controller 테스트: BaseController/ BaseErrorController 테스트.
- APIPlaceController  테스트 : 장소 리스트 조회 및 장소 상세 조회 테스트 추가. 테스트 속도 높이기 위해 APIPlaceController만 로드해서 controller 레이어 slice 테스트.