### PR TITLE
Event 관련 crud 로직 구현

### DIFF
--- a/src/main/java/com/example/realtimeusage/config/RepositoryConfig.java
+++ b/src/main/java/com/example/realtimeusage/config/RepositoryConfig.java
@@ -1,0 +1,13 @@
+package com.example.realtimeusage.config;
+
+import com.example.realtimeusage.repository.EventRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RepositoryConfig {
+    @Bean
+    public EventRepository eventRepository(){
+        return new EventRepository(){};
+    }
+}

--- a/src/main/java/com/example/realtimeusage/constant/ErrorCode.java
+++ b/src/main/java/com/example/realtimeusage/constant/ErrorCode.java
@@ -2,8 +2,10 @@ package com.example.realtimeusage.constant;
 
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
 
 @Getter
 @RequiredArgsConstructor
@@ -12,6 +14,7 @@ public enum ErrorCode {
 
     BAD_REQUEST(10000, ErrorCategory.CLIENT_SIDE, "bad request"),
     SPRING_BAD_REQUEST(10001, ErrorCategory.CLIENT_SIDE, "Spring-detected bad request"),
+    VALIDATION_ERROR(10002, ErrorCategory.CLIENT_SIDE, "validation failed"),
 
     INTERNAL_ERROR(20000, ErrorCategory.SERVER_SIDE, "internal error"),
     SPRING_INTERNAL_ERROR(20001, ErrorCategory.SERVER_SIDE, "Spring-detected internal error");
@@ -21,7 +24,7 @@ public enum ErrorCode {
     private final String message;
 
     public String getMessage(Exception e) {
-        return getMessage(e.getMessage());
+        return getMessage(this.getMessage() + " - " + e.getMessage());
     }
 
     public String getMessage(String message) {
@@ -29,6 +32,14 @@ public enum ErrorCode {
                 .filter(Predicate.not(String::isBlank))
                 .orElse(getMessage());
     }
+
+    public String getMessage(BindingResult bindingResult) {
+        return bindingResult.getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + " : " + error.getDefaultMessage())
+                .collect(Collectors.joining());
+    }
+
 
     public boolean isClientSideError() {
 //        return this.getErrorCategory() == ErrorCategory.CLIENT_SIDE;

--- a/src/main/java/com/example/realtimeusage/controller/api/APIEventController.java
+++ b/src/main/java/com/example/realtimeusage/controller/api/APIEventController.java
@@ -1,0 +1,80 @@
+package com.example.realtimeusage.controller.api;
+
+import com.example.realtimeusage.constant.EventStatus;
+import com.example.realtimeusage.dto.APIDataResponse;
+import com.example.realtimeusage.dto.EventRequest;
+import com.example.realtimeusage.dto.EventResponse;
+import com.example.realtimeusage.service.EventService;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/events")
+@RequiredArgsConstructor
+@Validated
+public class APIEventController {
+    private final EventService eventService;
+
+    @GetMapping
+    public APIDataResponse<List<EventResponse>> getEvents(
+            @Positive Long placeId,
+            @Size(min = 2) String name,
+            EventStatus eventStatus,
+            @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime startDateTime,
+            @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime endDateTime
+    ) {
+        return APIDataResponse.of(
+                eventService
+                        .getEvents(null, null, null, null, null)
+                        .stream().map(EventResponse::from)
+                        .toList()
+        );
+    }
+
+    @GetMapping("/{eventId}")
+    public APIDataResponse<EventResponse> getEvent(@Positive @PathVariable Long eventId) {
+        return APIDataResponse.of(eventService.getEvent(eventId).orElse(null));
+    }
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public APIDataResponse<String> createEvent(
+            @Valid @RequestBody EventRequest eventRequest) {
+        boolean result = eventService.createEvent(eventRequest.toDto(null));
+        return APIDataResponse.of(result);
+    }
+
+
+    @PutMapping("/{eventId}")
+    public APIDataResponse<String> modifyEvent(
+            @Positive @PathVariable Long eventId,
+            @Valid @RequestBody EventRequest eventRequest
+    ) {
+        boolean result = eventService.modifyEvent(eventId, eventRequest.toDto(null));
+        return APIDataResponse.of(Boolean.toString(result));
+    }
+
+    @DeleteMapping("/{eventId}")
+    public APIDataResponse<String> deleteEvent(@Positive @PathVariable Long eventId) {
+        boolean result = eventService.deleteEvent(eventId);
+        return APIDataResponse.of(Boolean.toString(result));
+    }
+
+
+}

--- a/src/main/java/com/example/realtimeusage/controller/error/APIExceptionHandler.java
+++ b/src/main/java/com/example/realtimeusage/controller/error/APIExceptionHandler.java
@@ -4,9 +4,12 @@ import com.example.realtimeusage.constant.ErrorCode;
 import com.example.realtimeusage.dto.APIErrorResponse;
 import com.example.realtimeusage.exception.GeneralException;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.ConstraintViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,7 +20,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class APIExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<Object> error(GeneralException e, HttpServletResponse response, WebRequest request) {
+    public ResponseEntity<Object> error(GeneralException e,  WebRequest request) {
         ErrorCode errorCode = e.getErrorCode();
         HttpStatus status = errorCode.isClientSideError() ? HttpStatus.BAD_REQUEST : HttpStatus.INTERNAL_SERVER_ERROR;
 
@@ -51,6 +54,17 @@ public class APIExceptionHandler extends ResponseEntityExceptionHandler {
                         ErrorCode.SPRING_INTERNAL_ERROR;
         return super.handleExceptionInternal(ex,
                 APIErrorResponse.of(errorCode.getCode(), errorCode.getMessage(ex.getMessage())), headers, status,
+                request);
+    }
+
+    @ExceptionHandler({ConstraintViolationException.class})
+    public ResponseEntity<Object> validationError(Exception ex, WebRequest request) {
+        ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        return super.handleExceptionInternal(ex,
+                APIErrorResponse.of(errorCode, errorCode.getMessage(ex)),
+                HttpHeaders.EMPTY,
+                status,
                 request);
     }
 }

--- a/src/main/java/com/example/realtimeusage/controller/error/BaseExceptionHandler.java
+++ b/src/main/java/com/example/realtimeusage/controller/error/BaseExceptionHandler.java
@@ -5,9 +5,10 @@ import com.example.realtimeusage.exception.GeneralException;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-//@ControllerAdvice
+@ControllerAdvice
 public class BaseExceptionHandler {
     @ExceptionHandler(GeneralException.class)
     public String error(GeneralException e, Model model, HttpServletResponse response) {
@@ -30,4 +31,5 @@ public class BaseExceptionHandler {
         model.addAttribute("message", errorCode.getMessage(e));
         return "error";
     }
+
 }

--- a/src/main/java/com/example/realtimeusage/dto/EventDto.java
+++ b/src/main/java/com/example/realtimeusage/dto/EventDto.java
@@ -1,0 +1,36 @@
+package com.example.realtimeusage.dto;
+
+import com.example.realtimeusage.constant.EventStatus;
+import java.time.LocalDateTime;
+
+public record EventDto(
+        Long id,
+        Long placeId,
+        String name,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
+        Integer capacity,
+        Integer currentNumberOfPeople,
+        EventStatus status,
+        String memo,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static EventDto of(
+            Long id,
+            Long placeId,
+            String name,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            Integer capacity,
+            Integer currentNumberOfPeople,
+            EventStatus status,
+            String memo,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+
+        return new EventDto(id, placeId, name, startDateTime,
+                endDateTime, capacity, currentNumberOfPeople, status, memo, createdAt, updatedAt);
+    }
+}

--- a/src/main/java/com/example/realtimeusage/dto/EventRequest.java
+++ b/src/main/java/com/example/realtimeusage/dto/EventRequest.java
@@ -1,0 +1,54 @@
+package com.example.realtimeusage.dto;
+
+import com.example.realtimeusage.constant.EventStatus;
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotBlank.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+public record EventRequest(
+        @NotBlank String name,
+        @NotNull  LocalDateTime startDateTime,
+        @NotNull  LocalDateTime endDateTime,
+        @NotNull @Positive Integer capacity,
+        @NotNull @PositiveOrZero Integer currentNumberOfPeople,
+        @NotNull EventStatus status,
+        String memo
+) {
+    public static EventRequest of(
+            String name,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            Integer capacity,
+            Integer currentNumberOfPeople,
+            EventStatus status,
+            String memo) {
+        return new EventRequest(
+                name,
+                startDateTime,
+                endDateTime,
+                capacity,
+                currentNumberOfPeople,
+                status,
+                memo
+        );
+    }
+
+    public EventDto toDto(PlaceDto placeDto) {
+        return EventDto.of(
+                null,
+                placeDto.id(),
+                name,
+                startDateTime,
+                endDateTime,
+                capacity,
+                currentNumberOfPeople,
+                status,
+                memo,
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/com/example/realtimeusage/dto/EventResponse.java
+++ b/src/main/java/com/example/realtimeusage/dto/EventResponse.java
@@ -1,0 +1,50 @@
+package com.example.realtimeusage.dto;
+
+import com.example.realtimeusage.constant.EventStatus;
+import java.time.LocalDateTime;
+
+public record EventResponse(
+        Long eventId,
+        Long placeId,
+        String name,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
+        Integer capacity,
+        Integer currentNumberOfPeople,
+        EventStatus status,
+        String memo
+) {
+    public static EventResponse of(
+            Long id,
+            Long placeId,
+            String name,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            Integer capacity,
+           Integer currentNumberOfPeople,
+            EventStatus status,
+            String memo) {
+
+        return new EventResponse(id, placeId, name, startDateTime,
+                endDateTime, capacity, currentNumberOfPeople, status, memo);
+    }
+
+    public static EventResponse from(EventDto eventDto) {
+        if (eventDto == null) {
+            return null; //NPE 방지
+        }
+        return EventResponse.of(
+                eventDto.id(),
+                eventDto.placeId(),
+                eventDto.name(),
+                eventDto.startDateTime(),
+                eventDto.endDateTime(),
+                eventDto.capacity(),
+                eventDto.currentNumberOfPeople(),
+                eventDto.status(),
+                eventDto.memo()
+        );
+    }
+
+
+}

--- a/src/main/java/com/example/realtimeusage/repository/EventRepository.java
+++ b/src/main/java/com/example/realtimeusage/repository/EventRepository.java
@@ -1,0 +1,55 @@
+package com.example.realtimeusage.repository;
+
+import com.example.realtimeusage.constant.EventStatus;
+import com.example.realtimeusage.dto.EventDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+// TODO: 2023/10/18 default 함수를 정의해서 bean으로 등록시 익명 클래스 구현 필요 없도록.
+public interface EventRepository {
+    default List<EventDto> findBy(
+            Long placeId,
+            String name,
+            EventStatus eventStatus,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime
+    ) {
+        return null;
+    }
+
+
+    default Optional<EventDto> findEventById(long eventId) {
+        return Optional.empty();
+    }
+
+    ;
+//    public Optional<EventDto> findEventById(long eventId) {
+//        if (eventId != 1L) {
+//            return Optional.empty();
+//        }
+//        return Optional.of(EventDto.of(
+//                1L,
+//                1L,
+//                "오전 운동",
+//                LocalDateTime.of(2021, 1, 1, 9, 0),
+//                LocalDateTime.of(2021, 1, 1, 12, 0),
+//                30,
+//                20,
+//                EventStatus.OPENED,
+//                ""
+//        ));
+//    }
+
+    default boolean create(EventDto eventDto) {
+        return true;
+    }
+
+    default boolean update(long eventId, EventDto eventDto) {
+        return true;
+    }
+
+    default boolean delete(long eventId) {
+        return true;
+    }
+}

--- a/src/main/java/com/example/realtimeusage/service/EventService.java
+++ b/src/main/java/com/example/realtimeusage/service/EventService.java
@@ -1,0 +1,42 @@
+package com.example.realtimeusage.service;
+
+import com.example.realtimeusage.constant.EventStatus;
+import com.example.realtimeusage.dto.EventDto;
+import com.example.realtimeusage.repository.EventRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+    private final EventRepository eventRepository;
+
+    public List<EventDto> getEvents(
+            Long placeId,
+            String name,
+            EventStatus eventStatus,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime
+    ) {
+        return eventRepository.findBy(placeId, name, eventStatus, startDateTime, endDateTime);
+    }
+
+    public Optional<EventDto> getEvent(long eventId) {
+        return eventRepository.findEventById(eventId);
+    }
+
+    public boolean createEvent(EventDto eventDto) {
+        return eventRepository.create(eventDto);
+    }
+
+    public boolean modifyEvent(long eventId, EventDto eventDto) {
+        return eventRepository.update(eventId, eventDto);
+    }
+
+    public boolean deleteEvent(long eventId) {
+        return eventRepository.delete(eventId);
+    }
+}

--- a/src/test/java/com/example/realtimeusage/controller/api/APIEventControllerTest.java
+++ b/src/test/java/com/example/realtimeusage/controller/api/APIEventControllerTest.java
@@ -1,0 +1,193 @@
+package com.example.realtimeusage.controller.api;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.realtimeusage.constant.ErrorCode;
+import com.example.realtimeusage.constant.EventStatus;
+import com.example.realtimeusage.dto.EventDto;
+import com.example.realtimeusage.dto.EventRequest;
+import com.example.realtimeusage.service.EventService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(APIEventController.class)
+class APIEventControllerTest {
+    private final MockMvc mvc;
+    private final ObjectMapper objectMapper;
+
+    @MockBean
+    private EventService eventService;
+
+    public APIEventControllerTest(@Autowired MockMvc mvc, @Autowired ObjectMapper objectMapper) {
+        this.mvc = mvc;
+        this.objectMapper = objectMapper;
+    }
+
+    @DisplayName("[API] [GET] 이벤트 리스트 조회")
+    @Test
+    void requestEventWithNoParameterShouldReturnStandardResponseOfEventList() throws Exception {
+        //given
+        given(eventService.getEvents(null, null, null, null, null))
+                .willReturn(List.of(createEventDto()));
+        //when & then
+        mvc.perform(get("/api/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].eventId").value(1L))
+                .andExpect(jsonPath("$.data[0].name").value("오후 운동"))
+                .andExpect(jsonPath("$.data[0].startDateTime")
+                        .value(LocalDateTime.of(2021, 1, 1, 13, 0, 0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
+                .andExpect(jsonPath("$.data[0].endDateTime")
+                        .value(LocalDateTime.of(2021, 1, 1, 16, 0, 0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
+                .andExpect(jsonPath("$.data[0].capacity").value(24))
+                .andExpect(jsonPath("$.data[0].currentNumberOfPeople").value(0))
+                .andExpect(jsonPath("$.data[0].status").value(EventStatus.OPENED.name()))
+                .andExpect(jsonPath("$.data[0].memo").value("마스크 꼭 착용하세요"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.OK.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.OK.getMessage()));
+        then(eventService).should().getEvents(null, null, null, null, null);
+    }
+
+    @DisplayName("[API] [GET] 이벤트 리스트 조회 - 검색 파라미터")
+    @Test
+    void requestEventWithParametersShouldReturnStandardResponseOfEventList() throws Exception {
+        //given
+        given(eventService.getEvents(any(), any(), any(), any(), any()))
+                .willReturn(List.of(createEventDto()));
+        //when & then
+        mvc.perform(get("/api/events")
+                        .queryParam("placeId", "1")
+                        .queryParam("name", "오후") //partial match
+                        .queryParam("eventStatus", EventStatus.OPENED.name())
+                        .queryParam("startDateTime",
+                                LocalDateTime.of(2021, 1, 1, 0, 0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                        .queryParam("endDateTime",
+                                LocalDateTime.of(2021, 1, 1, 0, 0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].eventId").value(1L))
+                .andExpect(jsonPath("$.data[0].name").value("오후 운동"))
+                .andExpect(jsonPath("$.data[0].startDateTime")
+                        .value(LocalDateTime.of(2021, 1, 1, 13, 0, 0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
+                .andExpect(jsonPath("$.data[0].endDateTime")
+                        .value(LocalDateTime.of(2021, 1, 1, 16, 0, 0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
+                .andExpect(jsonPath("$.data[0].capacity").value(24))
+                .andExpect(jsonPath("$.data[0].currentNumberOfPeople").value(0))
+                .andExpect(jsonPath("$.data[0].status").value(EventStatus.OPENED.name()))
+                .andExpect(jsonPath("$.data[0].memo").value("마스크 꼭 착용하세요"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.OK.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.OK.getMessage()));
+        then(eventService).should().getEvents(any(), any(), any(), any(), any());
+    }
+
+    @DisplayName("[API] [GET] 이벤트 리스트 조회 - 잘못된 검색 파라미터")
+    @Test
+    void requestEventWithInvalidParametersShouldReturnStandardErrorResponse() throws Exception {
+        //given - validation fail. mocking is not needed.
+        //when & then
+        mvc.perform(get("/api/events")
+                        .queryParam("placeId", "-1")
+                        .queryParam("name", "오") //partial match
+                        .queryParam("eventStatus", EventStatus.OPENED.name())
+                        .queryParam("startDateTime",
+                                LocalDateTime.of(2021, 1, 1, 0, 0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                        .queryParam("endDateTime",
+                                LocalDateTime.of(2021, 1, 1, 0, 0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.VALIDATION_ERROR.getCode()))
+                .andExpect(jsonPath("$.message").value(containsString(ErrorCode.VALIDATION_ERROR.getMessage())));
+
+        then(eventService).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("[API] [POST] 이벤트 생성")
+    @Test
+    void requestCreatingEventShouldCreateEventAndReturnStandardSuccessfulResponse() throws Exception {
+        //given
+        EventRequest requestDto = EventRequest.of(
+                "오후 운동",
+                LocalDateTime.of(2021, 1, 1, 13, 0, 0),
+                LocalDateTime.of(2021, 1, 1, 16, 0, 0),
+                24,
+                0,
+                EventStatus.OPENED,
+                "마스크 꼭 착용하세요"
+        );
+        given(eventService.createEvent(any())).willReturn(true);
+
+        //when & then
+        mvc.perform(post("/api/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.OK.getCode()))
+                .andExpect(jsonPath("$.message").value(containsString(ErrorCode.OK.getMessage())));
+
+        then(eventService).should().createEvent(any());
+    }
+
+    @DisplayName("[API] [POST] 이벤트 생성 - 잘못된 데이터 입력")
+    @Test
+    void requestCreatingEventWithInvalidBodyShouldReturnStandardErrorResponse() throws Exception {
+        EventRequest requestDto = EventRequest.of(
+                "오",
+                null,
+                null,
+                -1,
+                -1,
+                null,
+                "마스크 꼭 착용하세요"
+        );
+
+        //when & then
+        mvc.perform(post("/api/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.SPRING_BAD_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value(containsString(ErrorCode.SPRING_BAD_REQUEST.getMessage())));
+        then(eventService).shouldHaveNoInteractions();
+    }
+
+
+    private EventDto createEventDto() {
+        return EventDto.of(
+                1L,
+                null,
+                "오후 운동",
+                LocalDateTime.of(2021, 1, 1, 13, 0, 0),
+                LocalDateTime.of(2021, 1, 1, 16, 0, 0),
+                24,
+                0,
+                EventStatus.OPENED,
+                "마스크 꼭 착용하세요",
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/test/java/com/example/realtimeusage/service/EventServiceTest.java
+++ b/src/test/java/com/example/realtimeusage/service/EventServiceTest.java
@@ -1,0 +1,220 @@
+package com.example.realtimeusage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.example.realtimeusage.constant.EventStatus;
+import com.example.realtimeusage.dto.EventDto;
+import com.example.realtimeusage.repository.EventRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+    @InjectMocks
+    EventService sut; //system under test
+    @Mock
+    EventRepository eventRepository;
+
+
+    private EventDto createEventDto(Long id, String name, boolean isMorning) {
+        LocalDateTime hourStart = LocalDateTime.parse(String.format("2021-01-01T%s:00:00", isMorning ? "09" : "13"));
+        LocalDateTime hourEnd = LocalDateTime.parse(String.format("2021-01-01T%s:00:00", isMorning ? "12" : "16"));
+        return EventDto.of(
+                id,
+                null,
+                name,
+                hourStart,
+                hourEnd,
+                30,
+                20,
+                EventStatus.OPENED,
+                "",
+                null,
+                null
+        );
+
+    }
+
+    @DisplayName("검색 조건 없이 이벤트 검색하면 전체 리스트를 반환한다.")
+    @Test
+    void requestEventsWithNoParameterShouldReturnAllEvents() {
+        //given
+        given(eventRepository.findBy(null, null, null, null, null))
+                .willReturn(List.of(
+                        EventDto.of(1L, 1L, "event1", LocalDateTime.now(), LocalDateTime.now(), 30, 0,
+                                EventStatus.OPENED, "", null, null),
+                        EventDto.of(2L, 1L, "event2", LocalDateTime.now(), LocalDateTime.now(), 30, 0,
+                                EventStatus.OPENED, "", null, null)));
+
+        //when
+        List<EventDto> list = sut.getEvents(null, null, null, null, null);
+
+        //then
+        assertThat(list)
+                .hasSize(2);
+        then(eventRepository).should().findBy(null, null, null, null, null);
+    }
+
+    @DisplayName("검색 조건으로 이벤트 검색하면 조건에 맞는 이벤트 리스트를 반환한다.")
+    @Test
+    void requestEventsWithParametersShouldReturnEventList() {
+        //given
+        Long placeId = 1L;
+        String name = "오전 운동";
+        EventStatus status = EventStatus.OPENED;
+        LocalDateTime startDateTime = LocalDateTime.of(2021, 1, 1, 0, 0);
+        LocalDateTime endDateTime = LocalDateTime.of(2021, 1, 2, 0, 0);
+
+        given(eventRepository.findBy(placeId, name, status, startDateTime, endDateTime))
+                .willReturn(List.of(
+                        EventDto.of(
+                                1L,
+                                1L,
+                                "오전 운동",
+                                LocalDateTime.of(2021, 1, 1, 13, 0),
+                                LocalDateTime.of(2021, 1, 1, 16, 0),
+                                30,
+                                0,
+                                EventStatus.OPENED,
+                                "",
+                                null,
+                                null)
+                ));
+        //when
+        List<EventDto> list = sut.getEvents(placeId, name, status, startDateTime, endDateTime);
+        //then
+        assertThat(list)
+                .hasSize(1)
+                .allSatisfy(event -> {
+                    assertThat(event)
+                            .hasFieldOrPropertyWithValue("placeId", placeId)
+                            .hasFieldOrPropertyWithValue("name", name)
+                            .hasFieldOrPropertyWithValue("status", status);
+                    assertThat(event.startDateTime())
+                            .isAfterOrEqualTo(startDateTime);
+                    assertThat(event.endDateTime())
+                            .isBeforeOrEqualTo(endDateTime);
+                });
+
+        then(eventRepository).should().findBy(placeId, name, status, startDateTime, endDateTime);
+    }
+
+    @DisplayName("eventID로 존재하는 이벤트를 조회하면, 해당 이벤트 정보를 보여준다.")
+    @Test
+    void requestExistingEventShouldReturnEvent() {
+        //given
+        Long eventId = 1L;
+        EventDto eventDto = createEventDto(1L, "오전 운동", true);
+        given(eventRepository.findEventById(eventId)).willReturn(Optional.of(eventDto));
+        //when
+        Optional<EventDto> result = sut.getEvent(eventId);
+        //then
+        assertThat(result)
+                .isNotNull()
+                .get()
+                .hasFieldOrPropertyWithValue("eventId", eventId);
+        then(eventRepository).should().findEventById(eventId);
+    }
+
+    @DisplayName("eventID로 존재하지 않는 이벤트를 조회하면, 빈 정보를 출력하여 보여준다.")
+    @Test
+    void requestNoneExistingEventShouldReturnEmptyOptional() {
+        //given
+        Long eventId = 2L;
+        given(eventRepository.findEventById(eventId)).willReturn(Optional.empty());
+
+        //when
+        Optional<EventDto> result = sut.getEvent(eventId);
+
+        //then
+        assertThat(result).isEmpty();
+        then(eventRepository).should().findEventById(eventId);
+    }
+
+    @DisplayName("이벤트 정보를 주면, 이벤트를 생성하고 true를 반환한다.")
+    @Test
+    void requestCreatingEventShouldCreateEventAndReturnTrue() {
+        //given
+        EventDto eventDto = createEventDto(null, "오후 운동", false);
+        given(eventRepository.create(eventDto)).willReturn(true);
+
+        //when
+        boolean result = sut.createEvent(eventDto);
+
+        //then
+        assertThat(result).isTrue();
+        then(eventRepository).should().create(eventDto);
+    }
+
+    @DisplayName("이벤트 ID와 이벤트 정보를 주면, 이벤트 정보를 변경하고 true를 반환한다.")
+    @Test
+    void requestModifyingEventShouldModifyEventAndReturnTrue() {
+        //given
+        long eventId = 1L;
+        EventDto eventDto = createEventDto(eventId, "오후 운동", false);
+        given(eventRepository.update(eventId, eventDto)).willReturn(true);
+
+        //when
+        boolean result = sut.modifyEvent(eventId, eventDto);
+
+        //then
+        assertThat(result).isTrue();
+        then(eventRepository).should().update(eventId, eventDto);
+    }
+
+    @DisplayName("존재하지 않는 eventId를 주면, 이벤트 정보를 변경을 중단하고 false를 반환한다.")
+    @Test
+    void requestModifyingNoneExistingEventShouldAbortModifyingAndReturnFalse() {
+        //given
+        long noneExistingEventId = 2L;
+        EventDto eventDto = createEventDto(1L, "오후 운동", false);
+        given(eventRepository.update(noneExistingEventId, eventDto)).willReturn(false);
+
+        //when
+        boolean result = sut.modifyEvent(noneExistingEventId, eventDto);
+
+        //then
+        assertThat(result).isFalse();
+        then(eventRepository).should().update(noneExistingEventId, eventDto);
+    }
+
+    @DisplayName("이벤트 ID를 주면, 이벤트를 삭제하고 true를 반환한다.")
+    @Test
+    void requestDeletingExistingEventShouldDeleteEventAndReturnTrue() {
+        //given
+        long eventId = 1L;
+        given(eventRepository.delete(eventId)).willReturn(true);
+
+        //when
+        boolean result = sut.deleteEvent(eventId);
+
+        //then
+        assertThat(result).isTrue();
+        then(eventRepository).should().delete(eventId);
+    }
+
+    @DisplayName("이벤트 ID를 주면, 이벤트를 삭제하고 false를 반환한다.")
+    @Test
+    void requestDeletingNoneExistingEventShouldAbortDeletingAndReturnFalse() {
+        //given
+        long noneExistingEventId = 10L;
+        given(eventRepository.delete(noneExistingEventId)).willReturn(false);
+
+        //when
+        boolean result = sut.deleteEvent(noneExistingEventId);
+
+        //then
+        assertThat(result).isFalse();
+        then(eventRepository).should().delete(noneExistingEventId);
+    }
+
+}


### PR DESCRIPTION
###  event관련 controller, service, repository 구현
- repository는 default message가지는 interface로 구현하여 임시로 bean 등록. 이후 jpa repository로 교체 예정
- controller validation 추가하여 유효성 검증 관심사 분리. validation 예외는 APIExceptionHandler  혹은 Spring이 제공하는 ResponseEntityExceptionHandler에서 처리됨
### event관련 테스트 추가
- service layer는 mockbean사용하여 스프링 컨텍스트 없이 테스트. 빠른 테스트 가능하도록 함
- controller layer는 WebMvcTest로 해당 컨트롤러만 로드하여 최대한 가볍에 테스트. validation 테스트도 추가.