### PR TITLE
에러 처리 고도화

### DIFF
--- a/src/main/java/com/example/realtimeusage/constant/ErrorCode.java
+++ b/src/main/java/com/example/realtimeusage/constant/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     VALIDATION_ERROR(10002, ErrorCategory.CLIENT_SIDE, "validation failed"),
 
     INTERNAL_ERROR(20000, ErrorCategory.SERVER_SIDE, "internal error"),
-    SPRING_INTERNAL_ERROR(20001, ErrorCategory.SERVER_SIDE, "Spring-detected internal error");
+    SPRING_INTERNAL_ERROR(20001, ErrorCategory.SERVER_SIDE, "Spring-detected internal error"),
+    DATA_ACCESS_ERROR(20002, ErrorCategory.SERVER_SIDE, "data access error");
 
     private final Integer code;
     private final ErrorCategory errorCategory;
@@ -52,7 +53,7 @@ public enum ErrorCode {
 
     @Override
     public String toString() {
-        return String.format("%s (%d)", name(), this.getCode());
+        return String.format("%s (%d) : %s", name(), this.getCode(), this.getMessage());
     }
 
     public enum ErrorCategory {

--- a/src/main/java/com/example/realtimeusage/controller/error/APIExceptionHandler.java
+++ b/src/main/java/com/example/realtimeusage/controller/error/APIExceptionHandler.java
@@ -3,68 +3,71 @@ package com.example.realtimeusage.controller.error;
 import com.example.realtimeusage.constant.ErrorCode;
 import com.example.realtimeusage.dto.APIErrorResponse;
 import com.example.realtimeusage.exception.GeneralException;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.ConstraintViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-@RestControllerAdvice(annotations = RestController.class)
+@RestControllerAdvice(annotations = {RestController.class, Service.class})
 public class APIExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<Object> error(GeneralException e,  WebRequest request) {
-        ErrorCode errorCode = e.getErrorCode();
+    public ResponseEntity<Object> generalError(GeneralException ex, WebRequest request) {
+        ErrorCode errorCode = ex.getErrorCode();
         HttpStatus status = errorCode.isClientSideError() ? HttpStatus.BAD_REQUEST : HttpStatus.INTERNAL_SERVER_ERROR;
 
-        return super.handleExceptionInternal(e,
-                APIErrorResponse.of(errorCode.getCode(),
-                        errorCode.getMessage(e.getMessage())),
-                HttpHeaders.EMPTY,
-                status,
-                request);
+        return getObjectResponseEntity(ex, request, errorCode, status, HttpHeaders.EMPTY);
     }
 
     @ExceptionHandler
-    public ResponseEntity<Object> error(Exception e, WebRequest request) {
-        ErrorCode errorCode = ErrorCode.INTERNAL_ERROR;
-        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
-
-        return super.handleExceptionInternal(e,
-                APIErrorResponse.of(errorCode.getCode(),
-                        errorCode.getMessage(e.getMessage())),
-                HttpHeaders.EMPTY,
-                status,
-                request);
+    public ResponseEntity<Object> error(Exception ex, WebRequest request) {
+        return getObjectResponseEntity(
+                ex,
+                request,
+                ErrorCode.INTERNAL_ERROR,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                HttpHeaders.EMPTY);
     }
 
     @Override
-    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers,
-                                                             HttpStatus status, WebRequest request) {
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex,
+                                                             Object body,
+                                                             HttpHeaders headers,
+                                                             HttpStatus status,
+                                                             WebRequest request) {
         ErrorCode errorCode =
                 status.is4xxClientError() ?
                         ErrorCode.SPRING_BAD_REQUEST :
                         ErrorCode.SPRING_INTERNAL_ERROR;
-        return super.handleExceptionInternal(ex,
-                APIErrorResponse.of(errorCode.getCode(), errorCode.getMessage(ex.getMessage())), headers, status,
-                request);
+        return getObjectResponseEntity(ex, request, errorCode, status, headers);
     }
 
     @ExceptionHandler({ConstraintViolationException.class})
     public ResponseEntity<Object> validationError(Exception ex, WebRequest request) {
-        ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        return super.handleExceptionInternal(ex,
-                APIErrorResponse.of(errorCode, errorCode.getMessage(ex)),
-                HttpHeaders.EMPTY,
+        return getObjectResponseEntity(
+                ex,
+                request,
+                ErrorCode.VALIDATION_ERROR,
+                HttpStatus.BAD_REQUEST,
+                HttpHeaders.EMPTY);
+    }
+
+    private ResponseEntity<Object> getObjectResponseEntity(Exception e,
+                                                           WebRequest request,
+                                                           ErrorCode errorCode,
+                                                           HttpStatus status,
+                                                           HttpHeaders headers) {
+        return super.handleExceptionInternal(e,
+                APIErrorResponse.of(errorCode.getCode(), errorCode.getMessage(e)),
+                headers,
                 status,
                 request);
     }
+
 }

--- a/src/main/java/com/example/realtimeusage/dto/APIErrorResponse.java
+++ b/src/main/java/com/example/realtimeusage/dto/APIErrorResponse.java
@@ -2,12 +2,14 @@ package com.example.realtimeusage.dto;
 
 import com.example.realtimeusage.constant.ErrorCode;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@EqualsAndHashCode
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED) // 인스턴스 만들 수 있는 곳 -> dto 패키지 내부 혹은 상속받은 곳
 public class APIErrorResponse {
     private final Boolean success;

--- a/src/main/java/com/example/realtimeusage/service/EventService.java
+++ b/src/main/java/com/example/realtimeusage/service/EventService.java
@@ -1,7 +1,9 @@
 package com.example.realtimeusage.service;
 
+import com.example.realtimeusage.constant.ErrorCode;
 import com.example.realtimeusage.constant.EventStatus;
 import com.example.realtimeusage.dto.EventDto;
+import com.example.realtimeusage.exception.GeneralException;
 import com.example.realtimeusage.repository.EventRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,7 +23,11 @@ public class EventService {
             LocalDateTime startDateTime,
             LocalDateTime endDateTime
     ) {
-        return eventRepository.findBy(placeId, name, eventStatus, startDateTime, endDateTime);
+        try {
+            return eventRepository.findBy(placeId, name, eventStatus, startDateTime, endDateTime);
+        }catch (Exception e){
+            throw new GeneralException(ErrorCode.DATA_ACCESS_ERROR, e);
+        }
     }
 
     public Optional<EventDto> getEvent(long eventId) {

--- a/src/test/java/com/example/realtimeusage/constant/ErrorCodeTest.java
+++ b/src/test/java/com/example/realtimeusage/constant/ErrorCodeTest.java
@@ -1,0 +1,67 @@
+package com.example.realtimeusage.constant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ErrorCodeTest {
+    @DisplayName("예외를 받으면 예외 메시지가 포함된 메시지를 출력한다.")
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("getErrorCodeValues")// test하려는 함수와 같은 이름으로 static함수 선언
+    void gettingErrorCodeMessageWithGivenExceptionShouldReturnMessage(ErrorCode errorCode) {
+        //given
+        String message = "This is test exception";
+        Exception e = new Exception(message);
+
+        //when
+        String result = errorCode.getMessage(e);
+
+        //then
+        assertThat(result)
+                .isEqualTo(errorCode.getMessage() + " - " + message);
+    }
+
+    private static Stream<Arguments> getErrorCodeValues() {
+        return Arrays.stream(ErrorCode.values()).map(Arguments::arguments);
+    }
+
+    @DisplayName("메시지를 받으면 해당 에러 메시지를 출력한다.")
+    @ParameterizedTest(name = "[{index}] \"{0}\" -> {1}")
+    @MethodSource// test하려는 함수와 같은 이름으로 static함수 선언
+    void gettingErrorCodeMessageWithGivenMessageShouldReturnMessage(String input, String expected) {
+        //given
+        //when
+        String result = ErrorCode.INTERNAL_ERROR.getMessage(input);
+
+        //then
+        assertThat(result)
+                .isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> gettingErrorCodeMessageWithGivenMessageShouldReturnMessage(){
+        return Stream.of(
+                arguments(null, ErrorCode.INTERNAL_ERROR.getMessage()),
+                arguments("", ErrorCode.INTERNAL_ERROR.getMessage()),
+                arguments(" ", ErrorCode.INTERNAL_ERROR.getMessage()),
+                arguments("This is test message", "This is test message")
+                );
+    }
+
+    @DisplayName("toString()을 호출하면 에러 코드 정보를 출력한다.")
+    @ParameterizedTest(name = "[{index}] \"{0}\"")
+    @MethodSource("getErrorCodeValues")// test하려는 함수와 같은 이름으로 static함수 선언
+    void invokeToStringReturnErrorCodeDetail(ErrorCode errorCode) {
+        //when
+        String result = errorCode.toString();
+
+        //then
+        assertThat(result)
+                .contains(errorCode.getCode().toString(), errorCode.getMessage(), errorCode.name());
+    }
+}

--- a/src/test/java/com/example/realtimeusage/controller/error/APIExceptionHandlerTest.java
+++ b/src/test/java/com/example/realtimeusage/controller/error/APIExceptionHandlerTest.java
@@ -1,0 +1,85 @@
+package com.example.realtimeusage.controller.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.realtimeusage.constant.ErrorCode;
+import com.example.realtimeusage.dto.APIErrorResponse;
+import com.example.realtimeusage.exception.GeneralException;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.handler.DispatcherServletWebRequest;
+
+class APIExceptionHandlerTest {
+    private APIExceptionHandler sut;
+    private WebRequest webRequest;
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        sut = new APIExceptionHandler();
+        request = new MockHttpServletRequest();
+        webRequest = new DispatcherServletWebRequest(request);
+    }
+
+    @DisplayName("검증 오류 -응답 데이터")
+    @Test
+    void thrownConstraintViolationExceptionShouldReturnResponseEntityOfApiErrorResponse() {
+        //given
+        ConstraintViolationException e = new ConstraintViolationException(Set.of());
+
+        //when
+        ResponseEntity<Object> response = sut.validationError(e, webRequest);
+
+        //then
+        assertThat(response)
+                .hasFieldOrPropertyWithValue("headers", HttpHeaders.EMPTY)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST)
+                .hasFieldOrPropertyWithValue("body",
+                        APIErrorResponse.of(ErrorCode.VALIDATION_ERROR, ErrorCode.VALIDATION_ERROR.getMessage(e)));
+    }
+
+    @DisplayName("프로젝트 일반 오류 -응답 데이터")
+    @Test
+    void thrownGeneralExceptionShouldReturnResponseEntityOfApiErrorResponse() {
+        //given
+        ErrorCode errorCode = ErrorCode.INTERNAL_ERROR;
+        GeneralException e = new GeneralException(errorCode);
+
+        //when
+        ResponseEntity<Object> response = sut.generalError(e, webRequest);
+
+        //then
+        assertThat(response)
+                .hasFieldOrPropertyWithValue("headers", HttpHeaders.EMPTY)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.INTERNAL_SERVER_ERROR)
+                .hasFieldOrPropertyWithValue("body",
+                        APIErrorResponse.of(errorCode, errorCode.getMessage(e)));
+    }
+
+    @DisplayName("기타(전체)오류 -응답 데이터")
+    @Test
+    void thrownExceptionShouldReturnResponseEntityOfApiErrorResponse() {
+        //given
+        ErrorCode errorCode = ErrorCode.INTERNAL_ERROR;
+        Exception e = new Exception();
+
+        //when
+        ResponseEntity<Object> response = sut.error(e, webRequest);
+
+        //then
+        assertThat(response)
+                .hasFieldOrPropertyWithValue("headers", HttpHeaders.EMPTY)
+                .hasFieldOrPropertyWithValue("statusCode", HttpStatus.INTERNAL_SERVER_ERROR)
+                .hasFieldOrPropertyWithValue("body",
+                        APIErrorResponse.of(errorCode, errorCode.getMessage(e)));
+    }
+}


### PR DESCRIPTION
- ErrorCode에 dataAccessError 추가. 서비스 레이어에서 발생한 에러 general error로 전환되어 던져지는 것 테스트하기 위함
- errorCode테스트: 에러 메시지 및 toString 출력 포맷 통일 위한 테스트 메서드 추가
- ApiExceptionHandler 리팩토링. 공통 부분 메소드 추출하여 메소드 재사용
- ApiExceptionHandlerTest : 예외 처리 입출력 테스트 통해 출력 포맷 확인
- Service레이어에서 던져진 에러 처리 테스트