### PR TITLE
Feature/api AdminController 구현 및 테스트

### DIFF
--- a/src/main/java/com/example/realtimeusage/constant/AdminOperationStatus.java
+++ b/src/main/java/com/example/realtimeusage/constant/AdminOperationStatus.java
@@ -1,0 +1,14 @@
+package com.example.realtimeusage.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminOperationStatus {
+    CREATE("생성"),
+    MODIFY("수정"),
+    DELETE("삭제");
+    private final String message;
+}

--- a/src/main/java/com/example/realtimeusage/constant/ErrorCode.java
+++ b/src/main/java/com/example/realtimeusage/constant/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     BAD_REQUEST(10000, ErrorCategory.CLIENT_SIDE, "bad request"),
     SPRING_BAD_REQUEST(10001, ErrorCategory.CLIENT_SIDE, "Spring-detected bad request"),
     VALIDATION_ERROR(10002, ErrorCategory.CLIENT_SIDE, "validation failed"),
-    NOT_FOUND(10003, ErrorCategory.CLIENT_SIDE, "validation failed"),
+    NOT_FOUND(10003, ErrorCategory.CLIENT_SIDE, "resource not found"),
 
     INTERNAL_ERROR(20000, ErrorCategory.SERVER_SIDE, "internal error"),
     SPRING_INTERNAL_ERROR(20001, ErrorCategory.SERVER_SIDE, "Spring-detected internal error"),

--- a/src/main/java/com/example/realtimeusage/controller/AdminController.java
+++ b/src/main/java/com/example/realtimeusage/controller/AdminController.java
@@ -1,30 +1,225 @@
 package com.example.realtimeusage.controller;
 
+import com.example.realtimeusage.constant.AdminOperationStatus;
+import com.example.realtimeusage.constant.ErrorCode;
+import com.example.realtimeusage.constant.EventStatus;
+import com.example.realtimeusage.constant.PlaceType;
+import com.example.realtimeusage.domain.Event;
+import com.example.realtimeusage.domain.Place;
+import com.example.realtimeusage.dto.EventDto;
+import com.example.realtimeusage.dto.EventRequest;
+import com.example.realtimeusage.dto.EventResponse;
+import com.example.realtimeusage.dto.EventViewResponse;
+import com.example.realtimeusage.dto.PlaceDto;
+import com.example.realtimeusage.dto.PlaceRequest;
+import com.example.realtimeusage.dto.PlaceResponse;
+import com.example.realtimeusage.exception.GeneralException;
+import com.example.realtimeusage.service.EventService;
+import com.example.realtimeusage.service.PlaceService;
+import com.querydsl.core.types.Predicate;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequestMapping("/admin")
+@Validated
+@RequiredArgsConstructor
 public class AdminController {
+    private final EventService eventService;
+    private final PlaceService placeService;
+    public static final String PLACE_TYPE_OPTION = "placeTypeOption";
+    public static final String EVENT_STATUS_OPTION = "eventStatusOption";
+    public static final String REDIRECT_URL = "redirectUrl";
+    public static final String ADMIN_OPERATION_STATUS = "adminOperationStatus";
+
     @GetMapping("/places")
-    public String adminPlaces() {
+    public String adminPlaces(@QuerydslPredicate(root = Place.class) Predicate predicate, Model model) {
+        List<PlaceResponse> places = placeService.getPlaces(predicate)
+                .stream()
+                .map(PlaceResponse::of)
+                .toList();
+
+        model.addAttribute("places", places);
+        model.addAttribute(PLACE_TYPE_OPTION, PlaceType.values());
         return "/admin/places";
     }
 
     @GetMapping("/places/{placeId}")
-    public String adminPlaceDetail(@PathVariable Long placeId) {
+    public String adminPlaceDetail(
+            @Positive @PathVariable Long placeId,
+            @PageableDefault Pageable pageable,
+            Model model) {
+        PlaceResponse place = placeService.getPlace(placeId)
+                .map(PlaceResponse::of)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND));
+
+        Page<EventDto> events = eventService.getEvents(placeId, pageable);
+
+        model.addAttribute("place", place);
+        model.addAttribute("events", new PageImpl<>(
+                events.getContent().stream().map(EventViewResponse::of).toList(),
+                events.getPageable(),
+                events.getTotalElements()
+        ));
+        model.addAttribute(PLACE_TYPE_OPTION, PlaceType.values());
+        model.addAttribute(ADMIN_OPERATION_STATUS, AdminOperationStatus.MODIFY);
         return "/admin/place-detail";
     }
 
+    @GetMapping("/places/new")
+    public String newPlace(Model model) {
+        model.addAttribute(ADMIN_OPERATION_STATUS, AdminOperationStatus.CREATE);
+        model.addAttribute(PLACE_TYPE_OPTION, PlaceType.values());
+        return "/admin/place-detail";
+    }
+
+
+    @ResponseStatus(HttpStatus.SEE_OTHER) // Get /post/places로 redirect.
+    @PostMapping("/places")
+    public String upsertPlace(
+            @Valid @ModelAttribute PlaceRequest placeRequest,
+            RedirectAttributes redirectAttributes
+    ) {
+        AdminOperationStatus status =
+                placeRequest.id() != null ? AdminOperationStatus.MODIFY : AdminOperationStatus.CREATE;
+        boolean result = placeService.upsertPlace(placeRequest.toDto());
+        if (!result) {
+            throw new GeneralException(ErrorCode.BAD_REQUEST);
+        }
+
+        redirectAttributes.addFlashAttribute(ADMIN_OPERATION_STATUS, status);
+        redirectAttributes.addFlashAttribute(REDIRECT_URL, "/admin/places");
+
+        return "redirect:/admin/confirm";
+    }
+
+    @ResponseStatus(HttpStatus.SEE_OTHER) // Get /post/places로 redirect.
+    @DeleteMapping("/places/{placeId}")
+    public String deletePlace(
+            @Positive @PathVariable Long placeId,
+            RedirectAttributes redirectAttributes
+    ) {
+        boolean result = placeService.removePlace(placeId);
+        if (!result) {
+            throw new GeneralException(ErrorCode.BAD_REQUEST);
+        }
+
+        redirectAttributes.addFlashAttribute(ADMIN_OPERATION_STATUS, AdminOperationStatus.DELETE);
+        redirectAttributes.addFlashAttribute(REDIRECT_URL, "/admin/places");
+
+        return "redirect:/admin/confirm";
+    }
+
+    @GetMapping("/confirm")
+    public String confirm(Model model) {
+        if (!model.containsAttribute(REDIRECT_URL)) {
+            throw new GeneralException(ErrorCode.BAD_REQUEST);
+        }
+        return "/admin/confirm";
+    }
+
     @GetMapping("/events")
-    public String adminEvents() {
+    public String adminEvents(
+            @QuerydslPredicate(root = Event.class) Predicate predicate,
+            Model model
+    ) {
+        // TODO: 2023/11/02 Admin에 해당하는 event list만 반환하도록 수정 필요
+        List<EventResponse> events = eventService.getEvents(predicate)
+                .stream()
+                .map(EventResponse::of)
+                .toList();
+        model.addAttribute("events", events);
+        model.addAttribute(EVENT_STATUS_OPTION, EventStatus.values());
+
         return "/admin/events";
     }
 
+
     @GetMapping("/events/{eventId}")
-    public String adminEventDetail(@PathVariable Long eventId) {
+    public String getEventDetail(
+            @Positive @PathVariable Long eventId,
+            Model model
+    ) {
+        EventResponse event = eventService.getEvent(eventId)
+                .map(EventResponse::of)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND));
+        model.addAttribute("event", event);
+        model.addAttribute(ADMIN_OPERATION_STATUS, AdminOperationStatus.MODIFY);
+        model.addAttribute(EVENT_STATUS_OPTION, EventStatus.values());
+
         return "/admin/event-detail";
     }
+
+
+    @GetMapping("/places/{placeId}/newEvent")
+    public String getCreateEventPage(@Positive @PathVariable Long placeId, Model model) {
+        EventResponse emptyEvent = placeService.getPlace(placeId)
+                .map(EventResponse::empty)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND));
+        model.addAttribute("event", emptyEvent);
+        model.addAttribute(ADMIN_OPERATION_STATUS, AdminOperationStatus.CREATE);
+        model.addAttribute(EVENT_STATUS_OPTION, EventStatus.values());
+        return "/admin/event-detail";
+    }
+
+    @ResponseStatus(HttpStatus.SEE_OTHER)
+    @PostMapping("/places/{placeId}/events")
+    public String upsertEvent(
+            @Positive @PathVariable Long placeId,
+            @Valid EventRequest eventRequest,
+            RedirectAttributes redirectAttributes
+    ) {
+        PlaceDto placeDto = placeService.getPlace(placeId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND));
+
+        boolean result = eventService.upsertEvent(eventRequest.toDto(placeDto));
+        if (!result) {
+            throw new GeneralException(ErrorCode.BAD_REQUEST);
+        }
+
+        AdminOperationStatus status = eventRequest.id() != null
+                ? AdminOperationStatus.MODIFY
+                : AdminOperationStatus.CREATE;
+        redirectAttributes.addFlashAttribute(ADMIN_OPERATION_STATUS, status);
+        redirectAttributes.addFlashAttribute(REDIRECT_URL, "/admin/places/" + placeId);
+
+        // TODO: 2023/11/02 바로 /admin/confirm넘겨주면 안되나? redirect되야하는 페이지는 redirectUrl인데... 
+        return "redirect:/admin/confirm";
+    }
+
+    @ResponseStatus(HttpStatus.SEE_OTHER)
+    @DeleteMapping("/events/{eventId}")
+    public String deleteEvent(
+            @Positive @PathVariable Long eventId,
+            RedirectAttributes redirectAttributes
+    ) {
+        boolean result = eventService.removeEvent(eventId);
+        if (!result) {
+            throw new GeneralException(ErrorCode.BAD_REQUEST);
+        }
+
+        redirectAttributes.addFlashAttribute(ADMIN_OPERATION_STATUS, AdminOperationStatus.DELETE);
+        redirectAttributes.addFlashAttribute(REDIRECT_URL, "/admin/events");
+        return "redirect:/admin/confirm";
+    }
+
 }

--- a/src/main/java/com/example/realtimeusage/controller/EventController.java
+++ b/src/main/java/com/example/realtimeusage/controller/EventController.java
@@ -26,7 +26,7 @@ public class EventController {
     @GetMapping
     public String events(Model model, @QuerydslPredicate(root = Event.class) Predicate predicate) {
         model.addAttribute("events", eventService.getEvents(predicate)
-                .stream().map(EventResponse::from)
+                .stream().map(EventResponse::of)
                 .collect(Collectors.toList())
         );
         return "/event/index";
@@ -36,7 +36,7 @@ public class EventController {
     public String eventDetail(
             @Positive @NotNull @PathVariable Long eventId,
             Model model) {
-        model.addAttribute("event", eventService.getEvent(eventId).map(EventResponse::from));
+        model.addAttribute("event", eventService.getEvent(eventId).map(EventResponse::of));
         return "/event/detail";
     }
 }

--- a/src/main/java/com/example/realtimeusage/controller/error/APIExceptionHandler.java
+++ b/src/main/java/com/example/realtimeusage/controller/error/APIExceptionHandler.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-@RestControllerAdvice(annotations = {RestController.class, Service.class})
+@RestControllerAdvice(annotations = {RestController.class})
 public class APIExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(GeneralException.class)

--- a/src/main/java/com/example/realtimeusage/controller/error/BaseExceptionHandler.java
+++ b/src/main/java/com/example/realtimeusage/controller/error/BaseExceptionHandler.java
@@ -18,7 +18,7 @@ public class BaseExceptionHandler {
         model.addAttribute("statusCode", status.value());
         model.addAttribute("errorCode", errorCode);
         model.addAttribute("message", errorCode.getMessage(e));
-        return "error";
+        return "/error";
     }
 
     @ExceptionHandler
@@ -29,7 +29,7 @@ public class BaseExceptionHandler {
         model.addAttribute("statusCode", status.value());
         model.addAttribute("errorCode", errorCode);
         model.addAttribute("message", errorCode.getMessage(e));
-        return "error";
+        return "/error";
     }
 
 }

--- a/src/main/java/com/example/realtimeusage/dto/EventRequest.java
+++ b/src/main/java/com/example/realtimeusage/dto/EventRequest.java
@@ -2,22 +2,23 @@ package com.example.realtimeusage.dto;
 
 import com.example.realtimeusage.constant.EventStatus;
 import java.time.LocalDateTime;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotBlank.List;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 public record EventRequest(
-        @NotBlank String name,
-        @NotNull  LocalDateTime startDateTime,
-        @NotNull  LocalDateTime endDateTime,
-        @NotNull @Positive Integer capacity,
-        @NotNull @PositiveOrZero Integer currentNumberOfPeople,
-        @NotNull EventStatus status,
+        @Positive Long id,
+        String name,
+        @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime startDateTime,
+        @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime endDateTime,
+        @Positive Integer capacity,
+        @PositiveOrZero Integer currentNumberOfPeople,
+        EventStatus status,
         String memo
 ) {
     public static EventRequest of(
+            Long id,
             String name,
             LocalDateTime startDateTime,
             LocalDateTime endDateTime,
@@ -26,6 +27,7 @@ public record EventRequest(
             EventStatus status,
             String memo) {
         return new EventRequest(
+                id,
                 name,
                 startDateTime,
                 endDateTime,
@@ -38,7 +40,7 @@ public record EventRequest(
 
     public EventDto toDto(PlaceDto placeDto) {
         return EventDto.of(
-                null,
+                id,
                 placeDto,
                 name,
                 startDateTime,

--- a/src/main/java/com/example/realtimeusage/dto/EventResponse.java
+++ b/src/main/java/com/example/realtimeusage/dto/EventResponse.java
@@ -37,7 +37,7 @@ public record EventResponse(
                 memo);
     }
 
-    public static EventResponse from(EventDto eventDto) {
+    public static EventResponse of(EventDto eventDto) {
         if (eventDto == null) {
             return null; //NPE 방지
         }
@@ -55,4 +55,16 @@ public record EventResponse(
     }
 
 
+    public static EventResponse empty(PlaceDto placeDto) {
+        return new EventResponse(
+                null,
+                placeDto,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
 }

--- a/src/main/java/com/example/realtimeusage/dto/EventViewResponse.java
+++ b/src/main/java/com/example/realtimeusage/dto/EventViewResponse.java
@@ -1,0 +1,55 @@
+package com.example.realtimeusage.dto;
+
+import com.example.realtimeusage.constant.EventStatus;
+import java.time.LocalDateTime;
+
+public record EventViewResponse(
+        Long id,
+        String placeName,
+        String eventName,
+        EventStatus eventStatus,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
+        Integer currentNumberOfPeople,
+        Integer capacity,
+        String memo
+) {
+
+    public static EventViewResponse of(
+            Long id,
+            String placeName,
+            String eventName,
+            EventStatus eventStatus,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            Integer currentNumberOfPeople,
+            Integer capacity,
+            String memo
+    ) {
+        return new EventViewResponse(
+                id,
+                placeName,
+                eventName,
+                eventStatus,
+                startDateTime,
+                endDateTime,
+                currentNumberOfPeople,
+                capacity,
+                memo
+        );
+    }
+
+    public static EventViewResponse of(EventDto eventDto) {
+        return new EventViewResponse(
+                eventDto.id(),
+                eventDto.placeDto().name(),
+                eventDto.name(),
+                eventDto.status(),
+                eventDto.startDateTime(),
+                eventDto.endDateTime(),
+                eventDto.currentNumberOfPeople(),
+                eventDto.capacity(),
+                eventDto.memo()
+        );
+    }
+}

--- a/src/main/java/com/example/realtimeusage/dto/PlaceRequest.java
+++ b/src/main/java/com/example/realtimeusage/dto/PlaceRequest.java
@@ -1,0 +1,35 @@
+package com.example.realtimeusage.dto;
+
+import com.example.realtimeusage.constant.PlaceType;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+// TODO: 2023/11/02 Request객체를 create, update에 모두 사용하면 validation이 어렵지 않나... 
+public record PlaceRequest(
+        @Positive Long id,
+        @NotBlank String name,
+        @NotBlank String address,
+        @NotBlank String phoneNumber,
+        @NotNull PlaceType type,
+        @NotNull Boolean enabled,
+        @NotNull @PositiveOrZero Integer capacity,
+        String memo
+) {
+    public static PlaceRequest of(
+            Long id,
+            String name,
+            String address,
+            String phoneNumber,
+            PlaceType type,
+            Boolean enabled,
+            Integer capacity,
+            String memo) {
+        return new PlaceRequest(id, name, address, phoneNumber, type, enabled, capacity, memo);
+    }
+
+    public PlaceDto toDto() {
+        return PlaceDto.of(id, type, name, address, phoneNumber, capacity, memo, enabled, null, null);
+    }
+}

--- a/src/main/java/com/example/realtimeusage/dto/PlaceResponse.java
+++ b/src/main/java/com/example/realtimeusage/dto/PlaceResponse.java
@@ -19,4 +19,14 @@ public record PlaceResponse(
             String memo) {
         return new PlaceResponse(name, type, address, phoneNumber, capacity, memo);
     }
+    public static PlaceResponse of(PlaceDto placeDto){
+        return new PlaceResponse(
+                placeDto.name(),
+                placeDto.type(),
+                placeDto.address(),
+                placeDto.phoneNumber(),
+                placeDto.capacity(),
+                placeDto.memo()
+        );
+    }
 }

--- a/src/main/java/com/example/realtimeusage/repository/EventRepository.java
+++ b/src/main/java/com/example/realtimeusage/repository/EventRepository.java
@@ -1,10 +1,13 @@
 package com.example.realtimeusage.repository;
 
 import com.example.realtimeusage.domain.Event;
+import com.example.realtimeusage.domain.Place;
 import com.example.realtimeusage.domain.QEvent;
 import com.querydsl.core.types.dsl.ComparableExpression;
 import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.core.types.dsl.StringExpression;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
@@ -26,4 +29,6 @@ public interface EventRepository extends
         bindings.bind(root.startDateTime).first(ComparableExpression::goe);
         bindings.bind(root.endDateTime).first(ComparableExpression::loe);
     }
+
+    Page<Event> findByPlace(Place place, Pageable pageable);
 }

--- a/src/main/java/com/example/realtimeusage/repository/PlaceRepository.java
+++ b/src/main/java/com/example/realtimeusage/repository/PlaceRepository.java
@@ -2,9 +2,11 @@ package com.example.realtimeusage.repository;
 
 import com.example.realtimeusage.domain.Place;
 import com.example.realtimeusage.domain.QPlace;
+import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,5 +15,12 @@ public interface PlaceRepository extends
         QuerydslPredicateExecutor<Place>,
         QuerydslBinderCustomizer<QPlace>
 {
-
+    @Override
+    default void customize(QuerydslBindings bindings, QPlace root){
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.name, root.address, root.phoneNumber);
+        bindings.bind(root.name).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.address).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.phoneNumber).first(StringExpression::containsIgnoreCase);
+    }
 }

--- a/src/main/java/com/example/realtimeusage/service/PlaceService.java
+++ b/src/main/java/com/example/realtimeusage/service/PlaceService.java
@@ -50,10 +50,11 @@ public class PlaceService {
     }
 
     public boolean modifyPlace(Long placeId, PlaceDto placeDto) {
+        // TODO: 2023/11/02 BAD REQUEST VS NOTFOUND 구분해주는게 좋지 않을ㅓ까 
+        if (placeId == null || placeDto == null) {
+            return false;
+        }
         try {
-            if (placeId == null || placeDto == null) {
-                return false;
-            }
             Optional<Place> optionalPlace = placeRepository.findById(placeId);
             if (optionalPlace.isEmpty()) {
                 return false;
@@ -81,6 +82,21 @@ public class PlaceService {
             place.delete();
             placeRepository.save(place);
             return true;
+        } catch (Exception exception) {
+            throw new GeneralException(ErrorCode.DATA_ACCESS_ERROR, exception);
+        }
+    }
+
+    public boolean upsertPlace(PlaceDto dto) {
+        try {
+            if (dto == null) {
+                return false;
+            }
+            if (dto.id() != null) {
+                return createPlace(dto);
+            } else {
+                return modifyPlace(dto.id(), dto);
+            }
         } catch (Exception exception) {
             throw new GeneralException(ErrorCode.DATA_ACCESS_ERROR, exception);
         }

--- a/src/main/resources/templates/admin/plcaes.html
+++ b/src/main/resources/templates/admin/plcaes.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+This is admin places page.
+</body>
+</html>

--- a/src/test/java/com/example/realtimeusage/controller/AdminControllerTest.java
+++ b/src/test/java/com/example/realtimeusage/controller/AdminControllerTest.java
@@ -1,0 +1,449 @@
+package com.example.realtimeusage.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.example.realtimeusage.config.SecurityConfig;
+import com.example.realtimeusage.constant.AdminOperationStatus;
+import com.example.realtimeusage.constant.ErrorCode;
+import com.example.realtimeusage.constant.EventStatus;
+import com.example.realtimeusage.constant.PlaceType;
+import com.example.realtimeusage.dto.EventDto;
+import com.example.realtimeusage.dto.EventRequest;
+import com.example.realtimeusage.dto.EventResponse;
+import com.example.realtimeusage.dto.PlaceDto;
+import com.example.realtimeusage.dto.PlaceRequest;
+import com.example.realtimeusage.service.EventService;
+import com.example.realtimeusage.service.PlaceService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@DisplayName("View 컨트롤러 - 어드민")
+@WebMvcTest(
+        controllers = AdminController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+class AdminControllerTest {
+    @MockBean
+    private PlaceService placeService;
+    @MockBean
+    private EventService eventService;
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("[view][GET] 어드민 페이지 - 장소 리스트 뷰")
+    @Test
+    void givenQueryParams_whenRequestingAdminPlacesPage_thenReturnPlacesPage() throws Exception {
+        //given
+        given(placeService.getPlaces(any())).willReturn(List.of(
+                createPlaceDto(1L, "운동장", PlaceType.SPORTS, true),
+                createPlaceDto(2L, "파티룸", PlaceType.PARTY, true)
+        ));
+        //when
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/admin/places")
+                        .queryParam("address", "test address"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("/admin/places"))
+                .andExpect(model().hasNoErrors())
+                .andExpect(model().attributeExists("places", "placeTypeOption"))
+                .andExpect(model().attribute("places", hasSize(2)));
+        //then
+        then(placeService).should().getPlaces(any());
+    }
+
+    @DisplayName("[view][GET] 어드민 페이지 - 장소 상세 뷰")
+    @Test
+    void givenPlaceId_whenRequestingAdminPlacePage_thenReturnPlacePage() throws Exception {
+        //given
+        Long placeId = 1L;
+        given(placeService.getPlace(placeId)).willReturn(
+                Optional.of(createPlaceDto(1L, "운동장", PlaceType.SPORTS, true))
+        );
+        given(eventService.getEvents(any(), any())).willReturn(
+                new PageImpl<EventDto>(List.of()) {
+                }
+        );
+        //when
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/admin/places/" + placeId)
+                        .queryParam("size", "3"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("/admin/place-detail"))
+                .andExpect(model().hasNoErrors())
+                .andExpect(model().attributeExists("place", "events", "placeTypeOption", "adminOperationStatus"))
+                .andExpect(model().attribute("events", isA(Page.class)));
+        //then
+        then(placeService).should().getPlace(placeId);
+    }
+
+    @DisplayName("[view][GET] 어드민 페이지 - 장소 상세 뷰, 잘못된 placeId")
+    @Test
+    void givenNonExistingPlaceId_whenRequestingAdminPlacePage_thenReturnPlacePage() throws Exception {
+        //given
+        Long nonExistingPlaceId = -1L;
+        // service 가기전에 Controller validation error발생 ConstraintViolationError-> InternalServerError.
+        //when
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/admin/places/" + nonExistingPlaceId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("/error"))
+                .andExpect(model().attribute("errorCode", is(ErrorCode.INTERNAL_ERROR)))
+                .andExpect(model().attribute("statusCode", HttpStatus.INTERNAL_SERVER_ERROR.value()))
+                .andExpect(model().attribute("message", containsString("placeId")));
+        //then
+        then(placeService).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("[view][GET] 어드민 페이지 - 장소 생성 뷰")
+    @Test
+    void givenNothing_whenRequestingCreatingPlaceView_thenReturnCreatingPlaceView() throws Exception {
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.get("/admin/places/new"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("/admin/place-detail"))
+                .andExpect(model().hasNoErrors())
+                .andExpect(model().attribute("adminOperationStatus", AdminOperationStatus.CREATE))
+                .andExpect(model().attribute("placeTypeOption", PlaceType.values()));
+        //then
+        then(placeService).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("[view][POST] 어드민 페이지 - 장소 생성")
+    @Test
+    void givenNewPlace_whenRequestingCreatingPlace_thenSavesPlaceAndReturnsToListPage() throws Exception {
+        PlaceRequest newPlace = PlaceRequest.of(null, "테스트 장소", "테스트 주소", "02-111-1111", PlaceType.PARTY, true, 30,
+                null);
+
+        given(placeService.upsertPlace(any())).willReturn(true);
+        //mock bean안에서 같은 클래스안 함수 호출 없음. mockbean은 내용 없음
+
+        //redirect된 상태 아님.
+        mockMvc.perform(
+                        post("/admin/places")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .content(objectToFormData(newPlace)))
+                .andExpect(status().isSeeOther())
+                .andExpect(view().name("redirect:/admin/confirm"))
+                .andExpect(redirectedUrl("/admin/confirm"))
+                .andExpect(flash().attribute("redirectUrl", "/admin/places"))
+                .andExpect(flash().attribute("adminOperationStatus", AdminOperationStatus.CREATE))
+                .andDo(print());
+
+        then(placeService).should().upsertPlace(any());
+        then(placeService).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("[view][POST] 어드민 페이지 - 장소 수정")
+    @Test
+    void givenUpdatedPlace_whenRequestingCreatingPlace_thenModifiesPlaceAndReturnsToListPage() throws Exception {
+        Long placeId = 1L;
+        PlaceRequest updatedPlace = PlaceRequest.of(placeId, "new 테스트 장소", "테스트 주소", "02-111-1111", PlaceType.PARTY,
+                true, 30,
+                null);
+
+        given(placeService.upsertPlace(updatedPlace.toDto())).willReturn(true);
+
+        //redirect된 상태 아님.
+        mockMvc.perform(
+                        post("/admin/places")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .content(objectToFormData(updatedPlace)))
+                .andExpect(status().isSeeOther())
+                .andExpect(view().name("redirect:/admin/confirm"))
+                .andExpect(redirectedUrl("/admin/confirm"))
+                .andExpect(flash().attribute("redirectUrl", "/admin/places"))
+                .andExpect(flash().attribute("adminOperationStatus", AdminOperationStatus.MODIFY))
+                .andDo(print());
+
+        then(placeService).should().upsertPlace(any());
+        then(placeService).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("[view][DELETE] 어드민 페이지 - 장소 삭제")
+    @Test
+    void givenPlaceId_whenRequestingRemovingPlace_thenRemovesPlaceAndReturnsRedirectResponse() throws Exception {
+        Long placeId = 1L;
+        given(placeService.removePlace(placeId)).willReturn(true);
+
+        //redirect된 상태 아님.
+        mockMvc.perform(delete("/admin/places/" + placeId))
+                .andExpect(status().isSeeOther())
+                .andExpect(view().name("redirect:/admin/confirm"))
+                .andExpect(redirectedUrl("/admin/confirm"))
+                .andExpect(flash().attribute("adminOperationStatus", AdminOperationStatus.DELETE))
+                .andExpect(flash().attribute("redirectUrl", "/admin/places"));
+
+        then(placeService).should().removePlace(any());
+    }
+
+    @DisplayName("[view][GET] 어드민 페이지 - 이벤트 리스트 뷰")
+    @Test
+    void givenNothing_whenRequestingEventsPage_thenReturnEventsPage() throws Exception {
+        //given
+        given(eventService.getEvents(any()))
+                .willReturn(List.of(EventDto.of(
+                        1L,
+                        createPlaceDto(1L, "핫 파티룸", PlaceType.PARTY, true),
+                        "핫 파티룸에서 생일 파티",
+                        LocalDateTime.of(2021, 1, 1, 13, 0),
+                        LocalDateTime.of(2021, 1, 1, 16, 0),
+                        30,
+                        0,
+                        EventStatus.CLOSED,
+                        "",
+                        null,
+                        null
+                )));
+        //when
+        mockMvc.perform(get("/admin/events"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("/admin/events"))
+                .andExpect(model().hasNoErrors())
+                .andExpect(model().attribute("events", hasSize(1)))
+                .andExpect(model().attribute("eventStatusOption", EventStatus.values()));
+
+        //then
+        then(eventService).should().getEvents(any());
+    }
+
+    @DisplayName("[view][GET] 어드민 페이지 - 이벤트 디테일 및 수정 뷰")
+    @Test
+    void givenEventId_whenRequestingEventUpdatingPage_thenReturnEventUpdatingPage() throws Exception {
+        //given
+        Long eventId = 1L;
+        given(eventService.getEvent(eventId))
+                .willReturn(Optional.of(EventDto.of(
+                        eventId,
+                        createPlaceDto(1L, "핫 파티룸", PlaceType.PARTY, true),
+                        "핫 파티룸에서 생일 파티",
+                        LocalDateTime.of(2021, 1, 1, 13, 0),
+                        LocalDateTime.of(2021, 1, 1, 16, 0),
+                        30,
+                        0,
+                        EventStatus.CLOSED,
+                        "",
+                        null,
+                        null
+                )));
+        //when
+        mockMvc.perform(get("/admin/events/" + eventId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("/admin/event-detail"))
+                .andExpect(model().hasNoErrors())
+                .andExpect(model().attribute("event", isA(EventResponse.class)))
+                .andExpect(model().attribute("adminOperationStatus", AdminOperationStatus.MODIFY))
+                .andExpect(model().attribute("eventStatusOption", EventStatus.values()));
+
+        //then
+        then(eventService).should().getEvent(eventId);
+    }
+
+    @DisplayName("[view][GET] 어드민 페이지 - 이벤트 생성 뷰")
+    @Test
+    void givenPlaceId_whenRequestingEventCreatingPage_thenReturnEventCreatingPage() throws Exception {
+        //given
+        Long placeId = 1L;
+        given(placeService.getPlace(placeId))
+                .willReturn(Optional.of(createPlaceDto(placeId, "파티룸", PlaceType.PARTY, true)));
+        //when
+        mockMvc.perform(get("/admin/places/" + placeId + "/newEvent"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("/admin/event-detail"))
+                .andExpect(model().hasNoErrors())
+                .andExpect(model().attribute("event", isA(EventResponse.class)))
+                .andExpect(model().attributeExists("adminOperationStatus", "eventStatusOption"));
+
+        //then
+        then(placeService).should().getPlace(placeId);
+    }
+
+    @DisplayName("[view][GET] 어드민 페이지 - 이벤트 생성 뷰, 존재하지 않는 장소")
+    @Test
+    void givenNonExistingPlaceId_whenRequestingEventCreatingPage_thenReturnErrorPage() throws Exception {
+        //given
+        Long nonExistingPlaceId = 100L;
+        //when
+        mockMvc.perform(get("/admin/places/" + nonExistingPlaceId + "/newEvent"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("/error"))
+                .andExpect(model().attribute("statusCode", HttpStatus.BAD_REQUEST.value()))
+                .andExpect(model().attribute("errorCode", ErrorCode.NOT_FOUND))
+                .andExpect(model().attribute("message", containsString(ErrorCode.NOT_FOUND.getMessage())));
+
+        //then
+        then(placeService).should().getPlace(nonExistingPlaceId);
+    }
+
+    @DisplayName("[view][POST] 어드민 페이지 - 이벤트 생성")
+    @Test
+    void givenNewEvent_whenRequestingCreatingEvent_thenSavesEventAndReturnsToConfirmPage() throws Exception {
+        Long placeId = 1L;
+        EventRequest newEvent = EventRequest.of(
+                null,
+                "핫 파티룸에서 생일 파티",
+                LocalDateTime.of(2021, 1, 1, 13, 0),
+                LocalDateTime.of(2021, 1, 1, 16, 0),
+                30,
+                0,
+                EventStatus.CLOSED,
+                ""
+        );
+
+        given(placeService.getPlace(placeId)).willReturn(
+                Optional.of(createPlaceDto(placeId, "파티룸", PlaceType.PARTY, true)));
+//        given(placeService.getPlace(placeId)).willReturn(any());
+        given(eventService.upsertEvent(any())).willReturn(true);
+
+        mockMvc.perform(
+                        post("/admin/places/" + placeId + "/events")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .content(objectToFormData(newEvent)))
+                .andExpect(status().isSeeOther())
+                .andExpect(view().name("redirect:/admin/confirm"))
+                .andExpect(redirectedUrl("/admin/confirm"))
+                .andExpect(flash().attribute("redirectUrl", "/admin/places/" + placeId))
+                .andExpect(flash().attribute("adminOperationStatus", AdminOperationStatus.CREATE))
+                .andDo(print());
+
+        then(placeService).should().getPlace(placeId);
+        then(eventService).should().upsertEvent(any());
+        then(placeService).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("[view][POST] 어드민 페이지 - 이벤트 수정")
+    @Test
+    void givenUpdatedEvent_whenRequestingUpdatingEvent_thenModifiesEventAndReturnConfirmPage() throws Exception {
+        Long placeId = 1L;
+        Long eventId = 1L;
+        EventRequest updatedEvent = EventRequest.of(
+                eventId,
+                "핫 파티룸에서 생일 파티",
+                null,
+                null,
+                null,
+                null,
+                null,
+                ""
+        );
+        given(placeService.getPlace(placeId)).willReturn(
+                Optional.of(createPlaceDto(placeId, "파티룸", PlaceType.PARTY, true))
+        );
+        given(eventService.upsertEvent(any())).willReturn(true);
+
+        mockMvc.perform(
+                        post("/admin/places/" + placeId + "/events")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .content(objectToFormData(updatedEvent)))
+                .andExpect(status().isSeeOther())
+                .andExpect(view().name("redirect:/admin/confirm"))
+                .andExpect(redirectedUrl("/admin/confirm"))
+                .andExpect(flash().attribute("redirectUrl", "/admin/places/" + placeId))
+                .andExpect(flash().attribute("adminOperationStatus", AdminOperationStatus.MODIFY))
+                .andDo(print());
+
+        then(placeService).should().getPlace(placeId);
+        then(eventService).should().upsertEvent(any());
+        then(placeService).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("[view][DELETE] 어드민 페이지 - 이벤트 삭제")
+    @Test
+    void givenEventId_whenRequestDeletingEvent_thenReturnConfirmPage() throws Exception {
+        //given
+        Long eventId = 1L;
+        given(eventService.removeEvent(eventId)).willReturn(true);
+        //when
+        mockMvc.perform(delete("/admin/events/" + eventId))
+                .andExpect(status().isSeeOther())
+                .andExpect(view().name("redirect:/admin/confirm"))
+                .andExpect(model().hasNoErrors())
+                .andExpect(redirectedUrl("/admin/confirm"))
+                .andExpect(flash().attribute("redirectUrl", "/admin/events"))
+                .andExpect(flash().attribute("adminOperationStatus", AdminOperationStatus.DELETE));
+
+        //then
+        then(eventService).should().removeEvent(eventId);
+    }
+
+
+    @DisplayName("[view][GET] 어드민 페이지 - 확인 뷰")
+    @Test
+    void givenNothing_whenRequestingConfirm_thenReturnConfirmView() throws Exception {
+        //when
+        mockMvc.perform(get("/admin/confirm")
+                        .flashAttr("redirectUrl", "/admin/places")
+                        .flashAttr("adminOperationStatus", AdminOperationStatus.CREATE)
+                )
+                .andExpect(view().name("/admin/confirm"))
+                .andExpect(status().isOk());
+    }
+
+    private String objectToFormData(Object obj) {
+        Map<String, String> map = objectMapper.convertValue(obj, new TypeReference<>() {
+        });
+        return map.entrySet().stream()
+                .map(entry -> entry.getValue() == null
+                        ? ""
+                        : entry.getKey() + "=" + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+                .filter(str -> !str.isBlank())
+                .collect(Collectors.joining("&"));
+    }
+
+    private PlaceDto createPlaceDto(Long id, String name, PlaceType placeType, boolean enabled) {
+        return new PlaceDto(
+                id,
+                placeType,
+                name,
+                "test address",
+                "010-1111-1111",
+                30,
+                "",
+                enabled,
+                null,
+                null);
+    }
+
+}

--- a/src/test/java/com/example/realtimeusage/controller/api/APIEventControllerTest.java
+++ b/src/test/java/com/example/realtimeusage/controller/api/APIEventControllerTest.java
@@ -130,6 +130,7 @@ class APIEventControllerTest {
     void requestCreatingEventShouldCreateEventAndReturnStandardSuccessfulResponse() throws Exception {
         //given
         EventRequest requestDto = EventRequest.of(
+                1L,
                 "오후 운동",
                 LocalDateTime.of(2021, 1, 1, 13, 0, 0),
                 LocalDateTime.of(2021, 1, 1, 16, 0, 0),
@@ -157,6 +158,7 @@ class APIEventControllerTest {
     @Test
     void requestCreatingEventWithInvalidBodyShouldReturnStandardErrorResponse() throws Exception {
         EventRequest requestDto = EventRequest.of(
+                1L,
                 "오",
                 null,
                 null,


### PR DESCRIPTION
### 어드민 컨트롤러 구현
- 관련된 dto 및 service 구현 추가
- 서비스 레이어 처리 결과에 따라서 controller에서 general exception 발생시켜 구체적인 에러 상황(not found 혹은 data access error) 등 구분할 수 있도록 함.
-  Predicate 사용하여 키워드 검색이 가능하도록 cutomize binding 추가

### 테스트
- 테스트 displayname 사용하여 전체 테스트 실행시 어떤 내용이 포함되었는지 드러내도록함
- 메소드 이름을 given-when-then으로 지어 메소드 이름으로 테스트 내용 파악할 수 있도록 함.
- 테스트 given-when-then으로 구조 파악할 수 있도록 주석 및 BDDMockito 활용