### PR TITLE
feat: EventRepositoryCustom 인퍼페이스 및 구현

### DIFF
--- a/src/main/java/com/example/realtimeusage/exception/GeneralException.java
+++ b/src/main/java/com/example/realtimeusage/exception/GeneralException.java
@@ -2,7 +2,6 @@ package com.example.realtimeusage.exception;
 
 import com.example.realtimeusage.constant.ErrorCode;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
 public class GeneralException extends RuntimeException {
@@ -33,6 +32,17 @@ public class GeneralException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public GeneralException(ErrorCode errorCode, String message) {
+        super(errorCode.getMessage(message));
+        this.errorCode = errorCode;
+    }
+
+    public GeneralException(ErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode.getMessage(message), cause);
+        this.errorCode = errorCode;
+    }
+
     public GeneralException(ErrorCode errorCode, Throwable cause) {
         super(errorCode.getMessage(cause), cause);
         this.errorCode = errorCode;

--- a/src/main/java/com/example/realtimeusage/repository/EventRepository.java
+++ b/src/main/java/com/example/realtimeusage/repository/EventRepository.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface EventRepository extends
         JpaRepository<Event, Long>,
+        EventRepositoryCustom,
         QuerydslPredicateExecutor<Event>,
         QuerydslBinderCustomizer<QEvent> {
 

--- a/src/main/java/com/example/realtimeusage/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/example/realtimeusage/repository/EventRepositoryCustom.java
@@ -1,0 +1,18 @@
+package com.example.realtimeusage.repository;
+
+import com.example.realtimeusage.constant.EventStatus;
+import com.example.realtimeusage.dto.EventViewResponse;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface EventRepositoryCustom {
+    Page<EventViewResponse> findEventViewPageBySearchParam(
+            String placeName,
+            String eventName,
+            EventStatus eventStatus,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/example/realtimeusage/repository/EventRepositoryCustomImpl.java
+++ b/src/main/java/com/example/realtimeusage/repository/EventRepositoryCustomImpl.java
@@ -1,0 +1,70 @@
+package com.example.realtimeusage.repository;
+
+import com.example.realtimeusage.constant.ErrorCode;
+import com.example.realtimeusage.constant.EventStatus;
+import com.example.realtimeusage.domain.Event;
+import com.example.realtimeusage.domain.QEvent;
+import com.example.realtimeusage.dto.EventViewResponse;
+import com.example.realtimeusage.exception.GeneralException;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPQLQuery;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.util.StringUtils;
+
+public class EventRepositoryCustomImpl extends QuerydslRepositorySupport implements EventRepositoryCustom {
+    public EventRepositoryCustomImpl() {
+        super(Event.class);
+    }
+
+    @Override
+    public Page<EventViewResponse> findEventViewPageBySearchParam(
+            String placeName,
+            String eventName,
+            EventStatus eventStatus,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            Pageable pageable
+    ) {
+        QEvent event = QEvent.event;
+
+        JPQLQuery<EventViewResponse> query = from(event)
+                .select(Projections.constructor(
+                        EventViewResponse.class,
+                        event.id,
+                        event.place.name,
+                        event.name,
+                        event.status,
+                        event.startDateTime,
+                        event.endDateTime,
+                        event.currentNumberOfPeople,
+                        event.capacity,
+                        event.memo
+                ));
+
+        if(StringUtils.hasText(placeName)){
+            query.where(event.place.name.containsIgnoreCase(placeName));
+        }
+        if(StringUtils.hasText(eventName)){
+            query.where(event.name.containsIgnoreCase(eventName));
+        }
+        if(eventStatus!= null){
+            query.where(event.status.eq(eventStatus));
+        }
+        if(startDateTime!= null){
+            query.where(event.startDateTime.goe(startDateTime));
+        }
+        if(endDateTime!= null){
+            query.where(event.startDateTime.loe(endDateTime));
+        }
+        List<EventViewResponse> events = Optional.ofNullable(getQuerydsl())
+                .orElseThrow(() -> new GeneralException(ErrorCode.DATA_ACCESS_ERROR, "spring data jpa로부터 query dsl 인스턴스를 가져올 수 없다."))
+                .applyPagination(pageable,query).fetch();
+        return new PageImpl<>(events,pageable, query.fetchCount());
+    }
+}


### PR DESCRIPTION
- query dsl binder customer없이 직접 querydsl 구현하는 event repository custom 구현
- 복잡한 조회 쿼리 직접 생성하기 연습위함